### PR TITLE
オンラインCIサービスのセットアップ

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,81 @@
+sudo: false
+dist: trusty
+language: cpp
+
+matrix:
+  include:
+    # GCC5
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+      env:
+        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+
+    # GCC6
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+      env:
+        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+
+    # GCC7
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+      before_install:
+        - eval "${MATRIX_EVAL}"
+
+    # Clang 3.6
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.6
+          packages:
+            - clang-3.6
+      env:
+        - MATRIX_EVAL="CC=clang-3.6 && CXX=clang++-3.6"
+
+    # Clang 4.0
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-4.0
+          packages:
+            - clang-4.0
+      env:
+        - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
+
+    # Clang 5.0
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - clang-5.0
+      env:
+        - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
+
+before_install:
+  - eval "${MATRIX_EVAL}"
+
+script:
+  - cmake -H. -Bbuild
+  - cmake --build build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.1)
 
+project(dpcmc C CXX)
 set(CMAKE_CXX_STANDARD 11)
 
 if (MSVC)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,45 @@
+version: 1.0.{build}
+
+image: Visual Studio 2017
+
+environment:
+  matrix:
+  - generator: "Visual Studio 15"
+    config: Release
+    arch: vs2017-x86
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+
+  - generator: "Visual Studio 15 Win64"
+    config: Release
+    arch: vs2017-x64
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+
+  - generator: "Visual Studio 14"
+    config: Release
+    arch: vs2015-x86
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+
+  - generator: "Visual Studio 14 Win64"
+    config: Release
+    arch: vs2015-x64
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+
+init:
+  - git config --global core.autocrlf input
+
+build_script:
+  - cmake -G"%generator%" -H. -Bbuild
+  #- cmake --build build --config "%config%"
+  - msbuild build\dpcmc.sln /t:build /p:Configuration="%config%" /m /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
+after_build:
+  - ps: $env:git_hash = $env:appveyor_repo_commit.Substring(0, 8)
+  - ps: $env:my_version = "$env:appveyor_build_version-$env:git_hash"
+  - set package_name=dpcmc-%my_version%-%arch%
+  - mkdir lib
+  - copy "build\%config%\dpcmc.exe" bin\win32\dpcmc.exe
+  - 7z a %package_name%.zip README.md LICENSE bin fft stk main.cpp CMakeLists.txt
+
+artifacts:
+  - path: $(package_name).zip
+    name: $(arch)


### PR DESCRIPTION
オンラインCIサービスのビルドスクリプトを追加しました。

* [Travis CI](https://travis-ci.org/): Linux / OS X
    - ただ OS X はなぜか思うように動作しないので Linux のみの記述としました。
    - 参考: [Building a C Project \- Travis CI](https://docs.travis-ci.com/user/languages/c/)
* [AppVeyor](https://www.appveyor.com/): Windows 
    - こちらはビルドした成果物を zip ファイルとして収集するようにしました。
    - 参考: [appveyor\.yml Reference \| AppVeyor](https://www.appveyor.com/docs/appveyor-yml/)

どちらもビルド環境のマトリックスを多めに記述してあるので、多すぎるようであれば適宜マトリックスを減らしていただくと良いと思います。

### 導入メリットの一例

* Pull Request がビルド可能な状態か自動で判断できる（GitHub のコミット一覧にチェックマークが表示されるようになります）
    - さらに Windows については AppVeyor がビルド成果物を作ってくれるので動作確認も簡単
* README にビルドステータスを示すバッジを貼り付けられる

[![Travis Build Status](https://travis-ci.org/gocha/dpcmc.svg?branch=ci-setup)](https://travis-ci.org/gocha/dpcmc) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/dns0uho71s7dfxkt/branch/ci-setup?svg=true)](https://ci.appveyor.com/project/gocha/dpcmc/branch/ci-setup)

### 使い方

Travis CI、AppVeyor それぞれでアカウントを取得していただくと GitHub と同期できます。プロジェクトの一覧から動作を有効化すると、次のコミットから自動ビルドが開始されます（手動で HEAD をビルドさせることもできます）。

README や HTML ページにバッジを貼り付ける際のコードスニペットについては、それぞれのサービスのプロジェクト設定ページから取得できます。

とりとめないですが、もしよろしければご利用くださいませ。
